### PR TITLE
Update to not match URLs

### DIFF
--- a/weemoticons.py
+++ b/weemoticons.py
@@ -98,7 +98,7 @@ ICONS = {
     ':")': u'\U0001F633', '=")': u'\U0001F633',  # FLUSHED FACE
 }
 
-ICON_PATTERN = re.compile(r"[>:;=8B]+[\"'-]*[DSPp\\/\(\)<>]")
+ICON_PATTERN = re.compile(r"(?<!http)[>:;=8B]+[\"'-]*[DSPp\\/\(\)<>]")
 NOTICE_PATTERN = re.compile(r"(.*?:)(.*)")
 
 


### PR DESCRIPTION
URLs get broken with a unicode `:/` due to matching on `http://`. This update prevents that from happening.
